### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: ci
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/scrankin/spotfire-community/security/code-scanning/1](https://github.com/scrankin/spotfire-community/security/code-scanning/1)

To address the issue, we should explicitly specify the minimal required permissions for the workflow. The recommended way is to add a top-level `permissions` block at the start of the workflow, immediately after the `name` key but before any `on` or `jobs` keys. Based on the workflow contents (checking out code, caching dependencies, running tests and checks), only `contents: read` is likely needed. If later steps require more, these can be added selectively.

**Location to change:**  
Edit `.github/workflows/ci.yaml` and add:
```yaml
permissions:
  contents: read
```
directly after the `name: ci` entry, before the `on:` block.

No additional imports, definitions, or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
