### PR TITLE
Add SbdfStreamingWriter for memory-bounded SBDF generation

### DIFF
--- a/src/spotfire_community/sbdf/__init__.py
+++ b/src/spotfire_community/sbdf/__init__.py
@@ -1,24 +1,245 @@
-"""Helpers for converting tabular data to Spotfire Binary Data Format (SBDF).
+"""Helpers for producing Spotfire Binary Data Format (SBDF) files.
 
-This module exposes :func:`create_sbdf`, which accepts a CSV file-like object
-or a ``csv.reader`` and returns the raw SBDF bytes — ready to stream directly
-to the Spotfire Library API.
+Two public entry points:
+
+* :func:`create_sbdf` — a one-shot convenience that takes CSV/iterable input
+  and returns the full SBDF file as :class:`bytes`. Suitable for small tables.
+
+* :class:`SbdfStreamingWriter` — a low-level streaming writer that emits SBDF
+  bytes incrementally (file header, table slices, table end) so callers can
+  pipe the output to an upload target without materialising the full file in
+  memory. Suitable for tables that exceed available RAM.
 """
 
 from __future__ import annotations
 
 import csv
 import io
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
+from enum import IntEnum
 
-from spotfire_community.sbdf._writer import csv_to_sbdf as _csv_to_sbdf
+from spotfire_community.sbdf._writer import (
+    _SID_FILE_HEADER,
+    _SID_TABLE_END,
+    _SID_TABLE_METADATA,
+    _SID_TABLE_SLICE,
+    _VT_BOOL,
+    _VT_DOUBLE,
+    _VT_INT,
+    _VT_LONG,
+    _VT_STRING,
+    _column_slice,
+    _i32,
+    _infer_type,
+    _section,
+    _table_metadata,
+    csv_to_sbdf as _csv_to_sbdf,
+)
+
+
+class ValueType(IntEnum):
+    """SBDF column value types supported by this package."""
+
+    BOOL = _VT_BOOL
+    INT = _VT_INT
+    LONG = _VT_LONG
+    DOUBLE = _VT_DOUBLE
+    STRING = _VT_STRING
+
+
+def infer_types(
+    sample_rows: Iterable[Sequence[str]],
+    num_cols: int,
+) -> list[ValueType]:
+    """Infer a ``ValueType`` per column from a sample of stringified rows.
+
+    Args:
+        sample_rows: Iterable of rows (each row a sequence of strings). Rows
+            shorter than ``num_cols`` are padded with empty strings.
+        num_cols: Number of columns in the table.
+
+    Returns:
+        A list of ``num_cols`` :class:`ValueType` entries.
+    """
+    samples = [
+        [row[i] if i < len(row) else "" for i in range(num_cols)]
+        for row in sample_rows
+    ]
+    return [
+        ValueType(_infer_type([r[c] for r in samples])) for c in range(num_cols)
+    ]
+
+
+class SbdfStreamingWriter:
+    """Incremental SBDF writer.
+
+    Emits the SBDF sections (file header, table metadata, table slices, and
+    final table-end marker) as separate :class:`bytes` chunks so callers can
+    stream the output to an upload target without buffering the full file.
+
+    Example — streaming upload of a Snowflake cursor to a Spotfire library::
+
+        writer = SbdfStreamingWriter(
+            headers=["id", "name", "value"],
+            column_types=[ValueType.LONG, ValueType.STRING, ValueType.DOUBLE],
+        )
+
+        def row_batches() -> Iterator[list[list[str]]]:
+            while True:
+                rows = cursor.fetchmany(10_000)
+                if not rows:
+                    break
+                yield [[str(v) for v in row] for row in rows]
+
+        library_client.upload_file_streaming(
+            data_stream=writer.chunks(row_batches()),
+            path="/WiseRock/Customer/data.sbdf",
+            item_type=ItemType.SBDF,
+        )
+
+    Args:
+        headers: Column names, in order.
+        column_types: :class:`ValueType` per column. Must be the same length
+            as ``headers``. Use :func:`infer_types` to derive these from a
+            sample when the types are not known up front.
+
+    Raises:
+        ValueError: If ``headers`` and ``column_types`` have different lengths.
+    """
+
+    def __init__(
+        self,
+        headers: Sequence[str],
+        column_types: Sequence[ValueType],
+    ) -> None:
+        if len(headers) != len(column_types):
+            raise ValueError(
+                f"headers ({len(headers)}) and column_types ({len(column_types)}) "
+                "must have the same length"
+            )
+        self._headers = list(headers)
+        self._vtypes = [int(t) for t in column_types]
+        self._num_cols = len(headers)
+        self._started = False
+        self._finished = False
+
+    @property
+    def headers(self) -> list[str]:
+        return list(self._headers)
+
+    @property
+    def column_types(self) -> list[ValueType]:
+        return [ValueType(t) for t in self._vtypes]
+
+    def start(self) -> bytes:
+        """Emit the file header and table metadata.
+
+        Must be called exactly once, before any :meth:`write_slice` call.
+
+        Returns:
+            The bytes of the ``FileHeader`` + ``TableMetadata`` sections.
+
+        Raises:
+            RuntimeError: If called more than once.
+        """
+        if self._started:
+            raise RuntimeError("SbdfStreamingWriter.start() called more than once")
+        self._started = True
+        return (
+            _section(_SID_FILE_HEADER)
+            + bytes([1, 0])
+            + _section(_SID_TABLE_METADATA)
+            + _table_metadata(self._headers, self._vtypes)
+        )
+
+    def write_slice(self, rows: Sequence[Sequence[str]]) -> bytes:
+        """Encode a batch of rows as one SBDF ``TableSlice`` section.
+
+        Args:
+            rows: A sequence of stringified rows. Each row must have at least
+                as many elements as there are columns; extra elements are
+                ignored, missing elements are treated as empty strings.
+
+        Returns:
+            The bytes for a single ``TableSlice`` section. May be empty if
+            ``rows`` is empty, in which case no section is written.
+
+        Raises:
+            RuntimeError: If called before :meth:`start` or after :meth:`finish`.
+        """
+        if not self._started:
+            raise RuntimeError(
+                "SbdfStreamingWriter.write_slice() called before start()"
+            )
+        if self._finished:
+            raise RuntimeError(
+                "SbdfStreamingWriter.write_slice() called after finish()"
+            )
+        if not rows:
+            return b""
+        padded = [
+            [row[i] if i < len(row) else "" for i in range(self._num_cols)]
+            for row in rows
+        ]
+        out = bytearray()
+        out += _section(_SID_TABLE_SLICE)
+        out += _i32(self._num_cols)
+        for c in range(self._num_cols):
+            out += _column_slice([r[c] for r in padded], self._vtypes[c])
+        return bytes(out)
+
+    def finish(self) -> bytes:
+        """Emit the ``TableEnd`` marker. Must be called exactly once, last.
+
+        Returns:
+            The bytes of the ``TableEnd`` section.
+
+        Raises:
+            RuntimeError: If called before :meth:`start` or more than once.
+        """
+        if not self._started:
+            raise RuntimeError(
+                "SbdfStreamingWriter.finish() called before start()"
+            )
+        if self._finished:
+            raise RuntimeError(
+                "SbdfStreamingWriter.finish() called more than once"
+            )
+        self._finished = True
+        return _section(_SID_TABLE_END)
+
+    def chunks(
+        self,
+        row_batches: Iterable[Sequence[Sequence[str]]],
+    ) -> Iterator[bytes]:
+        """Yield SBDF bytes for an entire file, one section at a time.
+
+        Convenience wrapper that calls :meth:`start`, then :meth:`write_slice`
+        per batch, then :meth:`finish`. Each yielded chunk is a complete SBDF
+        section — safe to forward directly to a chunked upload API.
+
+        Args:
+            row_batches: Iterable of row batches. Each batch becomes one
+                ``TableSlice``. Empty batches are skipped silently.
+
+        Yields:
+            Non-empty :class:`bytes` chunks of SBDF data.
+        """
+        yield self.start()
+        for batch in row_batches:
+            slice_bytes = self.write_slice(batch)
+            if slice_bytes:
+                yield slice_bytes
+        yield self.finish()
 
 
 def create_sbdf(
     data: io.IOBase | Iterable[Sequence[str]],
     chunk_size: int = 10_000,
 ) -> bytes:
-    """Convert tabular data to Spotfire Binary Data Format (SBDF) bytes.
+    """Convert tabular data to SBDF bytes (one-shot, in-memory).
+
+    For large tables use :class:`SbdfStreamingWriter` instead.
 
     Args:
         data: Either a text-mode file-like object (e.g. ``open("f.csv")``,
@@ -61,4 +282,9 @@ def create_sbdf(
     return _csv_to_sbdf(buf.getvalue().encode(), chunk_size)
 
 
-__all__ = ["create_sbdf"]
+__all__ = [
+    "SbdfStreamingWriter",
+    "ValueType",
+    "create_sbdf",
+    "infer_types",
+]

--- a/src/spotfire_community/sbdf/__init__.py
+++ b/src/spotfire_community/sbdf/__init__.py
@@ -19,32 +19,36 @@ from collections.abc import Iterable, Iterator, Sequence
 from enum import IntEnum
 
 from spotfire_community.sbdf._writer import (
-    _SID_FILE_HEADER,
-    _SID_TABLE_END,
-    _SID_TABLE_METADATA,
-    _SID_TABLE_SLICE,
-    _VT_BOOL,
-    _VT_DOUBLE,
-    _VT_INT,
-    _VT_LONG,
-    _VT_STRING,
-    _column_slice,
-    _i32,
-    _infer_type,
-    _section,
-    _table_metadata,
+    SID_FILE_HEADER,
+    SID_TABLE_END,
+    SID_TABLE_METADATA,
+    SID_TABLE_SLICE,
+    VT_BOOL,
+    VT_DATE,
+    VT_DATETIME,
+    VT_DOUBLE,
+    VT_INT,
+    VT_LONG,
+    VT_STRING,
+    column_slice,
     csv_to_sbdf as _csv_to_sbdf,
+    i32,
+    infer_type,
+    section,
+    table_metadata,
 )
 
 
 class ValueType(IntEnum):
     """SBDF column value types supported by this package."""
 
-    BOOL = _VT_BOOL
-    INT = _VT_INT
-    LONG = _VT_LONG
-    DOUBLE = _VT_DOUBLE
-    STRING = _VT_STRING
+    BOOL = VT_BOOL
+    INT = VT_INT
+    LONG = VT_LONG
+    DOUBLE = VT_DOUBLE
+    DATETIME = VT_DATETIME
+    DATE = VT_DATE
+    STRING = VT_STRING
 
 
 def infer_types(
@@ -64,7 +68,7 @@ def infer_types(
     samples = [
         [row[i] if i < len(row) else "" for i in range(num_cols)] for row in sample_rows
     ]
-    return [ValueType(_infer_type([r[c] for r in samples])) for c in range(num_cols)]
+    return [ValueType(infer_type([r[c] for r in samples])) for c in range(num_cols)]
 
 
 class SbdfStreamingWriter:
@@ -143,10 +147,10 @@ class SbdfStreamingWriter:
             raise RuntimeError("SbdfStreamingWriter.start() called more than once")
         self._started = True
         return (
-            _section(_SID_FILE_HEADER)
+            section(SID_FILE_HEADER)
             + bytes([1, 0])
-            + _section(_SID_TABLE_METADATA)
-            + _table_metadata(self._headers, self._vtypes)
+            + section(SID_TABLE_METADATA)
+            + table_metadata(self._headers, self._vtypes)
         )
 
     def write_slice(self, rows: Sequence[Sequence[str]]) -> bytes:
@@ -179,10 +183,10 @@ class SbdfStreamingWriter:
             for row in rows
         ]
         out = bytearray()
-        out += _section(_SID_TABLE_SLICE)
-        out += _i32(self._num_cols)
+        out += section(SID_TABLE_SLICE)
+        out += i32(self._num_cols)
         for c in range(self._num_cols):
-            out += _column_slice([r[c] for r in padded], self._vtypes[c])
+            out += column_slice([r[c] for r in padded], self._vtypes[c])
         return bytes(out)
 
     def finish(self) -> bytes:
@@ -199,7 +203,7 @@ class SbdfStreamingWriter:
         if self._finished:
             raise RuntimeError("SbdfStreamingWriter.finish() called more than once")
         self._finished = True
-        return _section(_SID_TABLE_END)
+        return section(SID_TABLE_END)
 
     def chunks(
         self,

--- a/src/spotfire_community/sbdf/__init__.py
+++ b/src/spotfire_community/sbdf/__init__.py
@@ -62,12 +62,9 @@ def infer_types(
         A list of ``num_cols`` :class:`ValueType` entries.
     """
     samples = [
-        [row[i] if i < len(row) else "" for i in range(num_cols)]
-        for row in sample_rows
+        [row[i] if i < len(row) else "" for i in range(num_cols)] for row in sample_rows
     ]
-    return [
-        ValueType(_infer_type([r[c] for r in samples])) for c in range(num_cols)
-    ]
+    return [ValueType(_infer_type([r[c] for r in samples])) for c in range(num_cols)]
 
 
 class SbdfStreamingWriter:
@@ -198,13 +195,9 @@ class SbdfStreamingWriter:
             RuntimeError: If called before :meth:`start` or more than once.
         """
         if not self._started:
-            raise RuntimeError(
-                "SbdfStreamingWriter.finish() called before start()"
-            )
+            raise RuntimeError("SbdfStreamingWriter.finish() called before start()")
         if self._finished:
-            raise RuntimeError(
-                "SbdfStreamingWriter.finish() called more than once"
-            )
+            raise RuntimeError("SbdfStreamingWriter.finish() called more than once")
         self._finished = True
         return _section(_SID_TABLE_END)
 

--- a/src/spotfire_community/sbdf/_writer.py
+++ b/src/spotfire_community/sbdf/_writer.py
@@ -89,19 +89,32 @@ def section(sid: int) -> bytes:
 # ---------------------------------------------------------------------------
 
 
+def _timedelta_ms(dt: datetime) -> int:
+    """Return milliseconds from the SBDF epoch to *dt* using exact integer math.
+
+    ``timedelta.total_seconds()`` returns a float and can lose precision on
+    large deltas; computing from ``days``/``seconds``/``microseconds`` keeps
+    the result exact and deterministic.
+    """
+    delta = dt - _SBDF_EPOCH
+    return delta.days * 86_400_000 + delta.seconds * 1000 + delta.microseconds // 1000
+
+
 def _parse_datetime_ms(s: str) -> int | None:
     """Parse *s* as an ISO-8601 datetime; return milliseconds since SBDF epoch.
 
-    Returns ``None`` if *s* cannot be parsed. Naive inputs are interpreted as
-    UTC.
+    Accepts a trailing ``Z`` (UTC) which ``datetime.fromisoformat`` does not
+    handle natively on Python 3.10. Naive inputs (no offset) are interpreted
+    as UTC. Returns ``None`` if *s* cannot be parsed.
     """
+    normalized = s[:-1] + "+00:00" if s.endswith("Z") else s
     try:
-        dt = datetime.fromisoformat(s)
+        dt = datetime.fromisoformat(normalized)
     except ValueError:
         return None
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return int((dt - _SBDF_EPOCH).total_seconds() * 1000)
+    return _timedelta_ms(dt)
 
 
 def _parse_date_ms(s: str) -> int | None:
@@ -113,8 +126,7 @@ def _parse_date_ms(s: str) -> int | None:
         d = date.fromisoformat(s)
     except ValueError:
         return None
-    dt = datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
-    return int((dt - _SBDF_EPOCH).total_seconds() * 1000)
+    return _timedelta_ms(datetime(d.year, d.month, d.day, tzinfo=timezone.utc))
 
 
 # ---------------------------------------------------------------------------

--- a/src/spotfire_community/sbdf/_writer.py
+++ b/src/spotfire_community/sbdf/_writer.py
@@ -1,4 +1,9 @@
-"""Pure-Python SBDF binary writer (CSV → SBDF)."""
+"""Pure-Python SBDF binary writer (CSV → SBDF).
+
+Internal module. Callers should use :mod:`spotfire_community.sbdf`, which
+re-exports the high-level API (:func:`create_sbdf`, :class:`SbdfStreamingWriter`,
+:class:`ValueType`, :func:`infer_types`).
+"""
 
 from __future__ import annotations
 
@@ -6,26 +11,34 @@ import csv
 import io
 import struct
 from collections import deque
+from collections.abc import Sequence
+from datetime import date, datetime, timezone
 
 # Section IDs
-_SID_FILE_HEADER = 0x01
-_SID_TABLE_METADATA = 0x02
-_SID_TABLE_SLICE = 0x03
-_SID_COLUMN_SLICE = 0x04
-_SID_TABLE_END = 0x05
+SID_FILE_HEADER = 0x01
+SID_TABLE_METADATA = 0x02
+SID_TABLE_SLICE = 0x03
+SID_COLUMN_SLICE = 0x04
+SID_TABLE_END = 0x05
 
 # Value types
-_VT_BOOL = 0x01
-_VT_INT = 0x02
-_VT_LONG = 0x03
-_VT_DOUBLE = 0x05
-_VT_STRING = 0x0A
-_VT_BINARY = 0x0C
+VT_BOOL = 0x01
+VT_INT = 0x02
+VT_LONG = 0x03
+VT_DOUBLE = 0x05
+VT_DATETIME = 0x06
+VT_DATE = 0x07
+VT_STRING = 0x0A
+VT_BINARY = 0x0C
 
-_ENC_PLAIN = 0x01
-_ENC_BIT_ARRAY = 0x03
+ENC_PLAIN = 0x01
+ENC_BIT_ARRAY = 0x03
 
-_MAGIC = b"\xdf\x5b"
+MAGIC = b"\xdf\x5b"
+
+# Spotfire SBDF stores Date and DateTime as int64 milliseconds since
+# 0001-01-01 00:00:00 UTC. See pod2co/sbdf crate for reference semantics.
+_SBDF_EPOCH = datetime(1, 1, 1, tzinfo=timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -33,11 +46,11 @@ _MAGIC = b"\xdf\x5b"
 # ---------------------------------------------------------------------------
 
 
-def _i32(v: int) -> bytes:
+def i32(v: int) -> bytes:
     return struct.pack("<i", v)
 
 
-def _pack7(v: int) -> bytes:
+def pack7(v: int) -> bytes:
     """7-bit packed (LEB128-style) non-negative integer."""
     out = bytearray()
     for _ in range(5):
@@ -50,25 +63,58 @@ def _pack7(v: int) -> bytes:
     return bytes(out)
 
 
-def _str_u(s: str) -> bytes:
+def str_u(s: str) -> bytes:
     """String unpacked: i32(byte_len) + utf-8."""
     enc = s.encode()
-    return _i32(len(enc)) + enc
+    return i32(len(enc)) + enc
 
 
-def _str_p(s: str) -> bytes:
+def str_p(s: str) -> bytes:
     """String packed: pack7(byte_len) + utf-8."""
     enc = s.encode()
-    return _pack7(len(enc)) + enc
+    return pack7(len(enc)) + enc
 
 
-def _bytes_u(b: bytes) -> bytes:
+def bytes_u(b: bytes) -> bytes:
     """Bytes unpacked: i32(len) + data."""
-    return _i32(len(b)) + b
+    return i32(len(b)) + b
 
 
-def _section(sid: int) -> bytes:
-    return _MAGIC + bytes([sid])
+def section(sid: int) -> bytes:
+    return MAGIC + bytes([sid])
+
+
+# ---------------------------------------------------------------------------
+# Date/DateTime helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_datetime_ms(s: str) -> int | None:
+    """Parse *s* as an ISO-8601 datetime; return milliseconds since SBDF epoch.
+
+    Returns ``None`` if *s* cannot be parsed. Naive inputs are interpreted as
+    UTC.
+    """
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int((dt - _SBDF_EPOCH).total_seconds() * 1000)
+
+
+def _parse_date_ms(s: str) -> int | None:
+    """Parse *s* as an ISO date (YYYY-MM-DD); return milliseconds since SBDF epoch.
+
+    Returns ``None`` if *s* cannot be parsed.
+    """
+    try:
+        d = date.fromisoformat(s)
+    except ValueError:
+        return None
+    dt = datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+    return int((dt - _SBDF_EPOCH).total_seconds() * 1000)
 
 
 # ---------------------------------------------------------------------------
@@ -85,27 +131,40 @@ def _parse_bool(s: str) -> bool | None:
     return None
 
 
-def _infer_type(sample: list[str]) -> int:
+def infer_type(sample: list[str]) -> int:
+    """Pick the most specific SBDF value type that accepts every non-empty value.
+
+    Tries in order: Bool, Int, Long, Double, Date, DateTime, then falls back
+    to String. Empty strings are treated as null and do not constrain the type.
+    """
     nz = [v for v in sample if v]
     if not nz:
-        return _VT_STRING
+        return VT_STRING
     if all(_parse_bool(v) is not None for v in nz):
-        return _VT_BOOL
+        return VT_BOOL
     try:
         parsed = [int(v) for v in nz]
         if all(-(2**31) <= n <= 2**31 - 1 for n in parsed):
-            return _VT_INT
+            return VT_INT
         if all(-(2**63) <= n <= 2**63 - 1 for n in parsed):
-            return _VT_LONG
+            return VT_LONG
     except ValueError:
         pass
     try:
         for v in nz:
             float(v)
-        return _VT_DOUBLE
+        return VT_DOUBLE
     except ValueError:
         pass
-    return _VT_STRING
+    # Date is checked before DateTime so "YYYY-MM-DD" stays Date rather than
+    # promoting to DateTime (datetime.fromisoformat accepts bare dates).
+    if all(_parse_date_ms(v) is not None for v in nz) and not any(
+        "T" in v or " " in v for v in nz
+    ):
+        return VT_DATE
+    if all(_parse_datetime_ms(v) is not None for v in nz):
+        return VT_DATETIME
+    return VT_STRING
 
 
 # ---------------------------------------------------------------------------
@@ -121,11 +180,16 @@ def _bit_array_bytes(flags: list[bool]) -> bytes:
     return bytes(buf)
 
 
-def _column_slice(values: list[str], vtype: int) -> bytes:
-    """Encode one column as a ColumnSlice (section marker + values + props)."""
+def column_slice(values: list[str], vtype: int) -> bytes:
+    """Encode one column as a ColumnSlice (section marker + values + props).
+
+    Rows that cannot be parsed as *vtype* are encoded with a placeholder value
+    and marked in the column's IsInvalid bit array, matching the behaviour of
+    the existing Bool/Int/Long/Double branches.
+    """
     invalid: list[bool] = []
 
-    if vtype == _VT_BOOL:
+    if vtype == VT_BOOL:
         arr = bytearray()
         for s in values:
             b = _parse_bool(s)
@@ -135,10 +199,10 @@ def _column_slice(values: list[str], vtype: int) -> bytes:
             else:
                 invalid.append(False)
                 arr.append(1 if b else 0)
-        payload = _i32(len(values)) + bytes(arr)
-        value_bytes = bytes([_ENC_PLAIN, _VT_BOOL]) + payload
+        payload = i32(len(values)) + bytes(arr)
+        value_bytes = bytes([ENC_PLAIN, VT_BOOL]) + payload
 
-    elif vtype == _VT_INT:
+    elif vtype == VT_INT:
         arr = bytearray()
         for s in values:
             try:
@@ -147,9 +211,9 @@ def _column_slice(values: list[str], vtype: int) -> bytes:
             except (ValueError, struct.error):
                 arr += struct.pack("<i", 0)
                 invalid.append(True)
-        value_bytes = bytes([_ENC_PLAIN, _VT_INT]) + _i32(len(values)) + bytes(arr)
+        value_bytes = bytes([ENC_PLAIN, VT_INT]) + i32(len(values)) + bytes(arr)
 
-    elif vtype == _VT_LONG:
+    elif vtype == VT_LONG:
         arr = bytearray()
         for s in values:
             try:
@@ -158,9 +222,9 @@ def _column_slice(values: list[str], vtype: int) -> bytes:
             except (ValueError, struct.error):
                 arr += struct.pack("<q", 0)
                 invalid.append(True)
-        value_bytes = bytes([_ENC_PLAIN, _VT_LONG]) + _i32(len(values)) + bytes(arr)
+        value_bytes = bytes([ENC_PLAIN, VT_LONG]) + i32(len(values)) + bytes(arr)
 
-    elif vtype == _VT_DOUBLE:
+    elif vtype == VT_DOUBLE:
         arr = bytearray()
         for s in values:
             try:
@@ -169,18 +233,41 @@ def _column_slice(values: list[str], vtype: int) -> bytes:
             except (ValueError, struct.error):
                 arr += struct.pack("<d", 0.0)
                 invalid.append(True)
-        value_bytes = bytes([_ENC_PLAIN, _VT_DOUBLE]) + _i32(len(values)) + bytes(arr)
+        value_bytes = bytes([ENC_PLAIN, VT_DOUBLE]) + i32(len(values)) + bytes(arr)
 
-    else:  # _VT_STRING
+    elif vtype == VT_DATETIME:
+        arr = bytearray()
+        for s in values:
+            ms = _parse_datetime_ms(s) if s else None
+            if ms is None:
+                invalid.append(True)
+                arr += struct.pack("<q", 0)
+            else:
+                invalid.append(False)
+                arr += struct.pack("<q", ms)
+        value_bytes = bytes([ENC_PLAIN, VT_DATETIME]) + i32(len(values)) + bytes(arr)
+
+    elif vtype == VT_DATE:
+        arr = bytearray()
+        for s in values:
+            ms = _parse_date_ms(s) if s else None
+            if ms is None:
+                invalid.append(True)
+                arr += struct.pack("<q", 0)
+            else:
+                invalid.append(False)
+                arr += struct.pack("<q", ms)
+        value_bytes = bytes([ENC_PLAIN, VT_DATE]) + i32(len(values)) + bytes(arr)
+
+    else:  # VT_STRING
         parts = bytearray()
         for s in values:
             invalid.append(len(s) == 0)
-            parts += _str_p(s)
-        # count + total_byte_size of packed strings + packed strings
+            parts += str_p(s)
         value_bytes = (
-            bytes([_ENC_PLAIN, _VT_STRING])
-            + _i32(len(values))
-            + _i32(len(parts))
+            bytes([ENC_PLAIN, VT_STRING])
+            + i32(len(values))
+            + i32(len(parts))
             + bytes(parts)
         )
 
@@ -188,16 +275,16 @@ def _column_slice(values: list[str], vtype: int) -> bytes:
     if has_invalid:
         bit_bytes = _bit_array_bytes(invalid)
         is_invalid = (
-            _str_u("IsInvalid")
-            + bytes([_ENC_BIT_ARRAY, _VT_BOOL])
-            + _i32(len(invalid))
+            str_u("IsInvalid")
+            + bytes([ENC_BIT_ARRAY, VT_BOOL])
+            + i32(len(invalid))
             + bit_bytes
         )
-        props = _i32(1) + is_invalid
+        props = i32(1) + is_invalid
     else:
-        props = _i32(0)
+        props = i32(0)
 
-    return _section(_SID_COLUMN_SLICE) + value_bytes + props
+    return section(SID_COLUMN_SLICE) + value_bytes + props
 
 
 # ---------------------------------------------------------------------------
@@ -205,35 +292,35 @@ def _column_slice(values: list[str], vtype: int) -> bytes:
 # ---------------------------------------------------------------------------
 
 
-def _table_metadata(headers: list[str], vtypes: list[int]) -> bytes:
+def table_metadata(headers: Sequence[str], vtypes: Sequence[int]) -> bytes:
     num_cols = len(headers)
     out = bytearray()
 
     # Table-level metadata: [TableColumns = Int(num_cols)]
-    out += _i32(1)
-    out += _str_u("TableColumns")
-    out += bytes([_VT_INT])
-    out += bytes([1]) + _i32(num_cols)  # present=1, value
+    out += i32(1)
+    out += str_u("TableColumns")
+    out += bytes([VT_INT])
+    out += bytes([1]) + i32(num_cols)  # present=1, value
     out += bytes([0])  # no default
 
     # Column count
-    out += _i32(num_cols)
+    out += i32(num_cols)
 
     # Unique column metadata types: Name (String) and DataType (Binary)
-    out += _i32(2)
-    out += _str_u("Name") + bytes([_VT_STRING]) + bytes([0])
-    out += _str_u("DataType") + bytes([_VT_BINARY]) + bytes([0])
+    out += i32(2)
+    out += str_u("Name") + bytes([VT_STRING]) + bytes([0])
+    out += str_u("DataType") + bytes([VT_BINARY]) + bytes([0])
 
     # Per-column: present + value for each metadata type
     for name, vtype in zip(headers, vtypes):
-        out += bytes([1]) + _str_u(name)
-        out += bytes([1]) + _bytes_u(bytes([vtype]))
+        out += bytes([1]) + str_u(name)
+        out += bytes([1]) + bytes_u(bytes([vtype]))
 
     return bytes(out)
 
 
 # ---------------------------------------------------------------------------
-# Public entry point
+# Public entry point (used by create_sbdf)
 # ---------------------------------------------------------------------------
 
 
@@ -256,11 +343,11 @@ def csv_to_sbdf(
     for _, row in zip(range(sample_rows), reader):
         sampled.append(_pad(row))
 
-    vtypes = [_infer_type([r[c] for r in sampled]) for c in range(num_cols)]
+    vtypes = [infer_type([r[c] for r in sampled]) for c in range(num_cols)]
 
     out = bytearray()
-    out += _section(_SID_FILE_HEADER) + bytes([1, 0])
-    out += _section(_SID_TABLE_METADATA) + _table_metadata(headers, vtypes)
+    out += section(SID_FILE_HEADER) + bytes([1, 0])
+    out += section(SID_TABLE_METADATA) + table_metadata(headers, vtypes)
 
     # Phase 2: stream table slices from sampled queue + remaining rows
     queue: deque[list[str]] = deque(sampled)
@@ -279,13 +366,13 @@ def csv_to_sbdf(
         chunk = [queue.popleft() for _ in range(take)]
         at_eof = take < chunk_size
 
-        out += _section(_SID_TABLE_SLICE)
-        out += _i32(num_cols)
+        out += section(SID_TABLE_SLICE)
+        out += i32(num_cols)
         for c in range(num_cols):
-            out += _column_slice([r[c] for r in chunk], vtypes[c])
+            out += column_slice([r[c] for r in chunk], vtypes[c])
 
         if at_eof:
             break
 
-    out += _section(_SID_TABLE_END)
+    out += section(SID_TABLE_END)
     return bytes(out)

--- a/tests/unit/sbdf/test_streaming_writer.py
+++ b/tests/unit/sbdf/test_streaming_writer.py
@@ -147,8 +147,27 @@ def test_infer_types_detects_date() -> None:
 
 
 def test_infer_types_detects_datetime() -> None:
-    sample = [["2025-01-01T12:34:56"], ["2025-06-15 09:00:00"]]
+    sample = [
+        ["2025-01-01T12:34:56"],
+        ["2025-06-15 09:00:00"],
+        ["2025-01-01T12:34:56Z"],
+        ["2025-01-01T12:34:56+02:00"],
+    ]
     assert infer_types(sample, num_cols=1) == [ValueType.DATETIME]
+
+
+def test_parse_datetime_handles_utc_suffix_and_offsets() -> None:
+    from spotfire_community.sbdf._writer import _parse_datetime_ms
+
+    # 'Z' suffix is normalized to +00:00 so Python 3.10 can parse it.
+    z_ms = _parse_datetime_ms("2025-01-01T12:34:56Z")
+    plus_zero_ms = _parse_datetime_ms("2025-01-01T12:34:56+00:00")
+    assert z_ms == plus_zero_ms
+
+    # Non-UTC offset is applied, not silently dropped.
+    plus_two_ms = _parse_datetime_ms("2025-01-01T12:34:56+02:00")
+    # +02:00 means the same instant is 10:34:56 UTC, so its ms count is smaller.
+    assert plus_two_ms == z_ms - 2 * 60 * 60 * 1000
 
 
 def test_infer_types_falls_back_to_string_when_date_parse_fails() -> None:
@@ -164,14 +183,12 @@ def test_writer_date_column_roundtrip_math() -> None:
     from spotfire_community.sbdf._writer import _parse_date_ms
 
     assert _parse_date_ms("0001-01-01") == 0
-    # 2025-01-01 is a known offset; verify against direct datetime math.
-    expected = int(
-        (
-            datetime(2025, 1, 1, tzinfo=timezone.utc)
-            - datetime(1, 1, 1, tzinfo=timezone.utc)
-        ).total_seconds()
-        * 1000
+    # 2025-01-01 is a known offset; verify against integer timedelta math
+    # (days * 86_400_000) rather than total_seconds() float conversion.
+    delta = datetime(2025, 1, 1, tzinfo=timezone.utc) - datetime(
+        1, 1, 1, tzinfo=timezone.utc
     )
+    expected = delta.days * 86_400_000
     assert _parse_date_ms("2025-01-01") == expected
 
 

--- a/tests/unit/sbdf/test_streaming_writer.py
+++ b/tests/unit/sbdf/test_streaming_writer.py
@@ -18,7 +18,13 @@ _SBDF_MAGIC = b"\xdf\x5b"
 
 def test_value_type_members_distinct() -> None:
     # Each supported SBDF type maps to a distinct underlying int.
-    codes = {ValueType.BOOL, ValueType.INT, ValueType.LONG, ValueType.DOUBLE, ValueType.STRING}
+    codes = {
+        ValueType.BOOL,
+        ValueType.INT,
+        ValueType.LONG,
+        ValueType.DOUBLE,
+        ValueType.STRING,
+    }
     assert len(codes) == 5
 
 
@@ -80,9 +86,7 @@ def test_writer_matches_create_sbdf_byte_for_byte() -> None:
 
 
 def test_writer_low_level_methods() -> None:
-    writer = SbdfStreamingWriter(
-        headers=["n"], column_types=[ValueType.INT]
-    )
+    writer = SbdfStreamingWriter(headers=["n"], column_types=[ValueType.INT])
     head = writer.start()
     slice_bytes = writer.write_slice([["1"], ["2"]])
     tail = writer.finish()
@@ -93,17 +97,13 @@ def test_writer_low_level_methods() -> None:
 
 
 def test_writer_empty_slice_is_skipped() -> None:
-    writer = SbdfStreamingWriter(
-        headers=["n"], column_types=[ValueType.INT]
-    )
+    writer = SbdfStreamingWriter(headers=["n"], column_types=[ValueType.INT])
     writer.start()
     assert writer.write_slice([]) == b""
 
 
 def test_writer_chunks_skips_empty_batches() -> None:
-    writer = SbdfStreamingWriter(
-        headers=["n"], column_types=[ValueType.INT]
-    )
+    writer = SbdfStreamingWriter(headers=["n"], column_types=[ValueType.INT])
     chunks = list(writer.chunks(iter([[["1"]], [], [["2"]]])))
     # header, slice-1, slice-2, end = 4 chunks (middle empty batch dropped).
     assert len(chunks) == 4

--- a/tests/unit/sbdf/test_streaming_writer.py
+++ b/tests/unit/sbdf/test_streaming_writer.py
@@ -1,0 +1,150 @@
+"""Unit tests for SbdfStreamingWriter and infer_types helpers."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from spotfire_community.sbdf import (
+    SbdfStreamingWriter,
+    ValueType,
+    create_sbdf,
+    infer_types,
+)
+
+_SBDF_MAGIC = b"\xdf\x5b"
+
+
+def test_value_type_members_distinct() -> None:
+    # Each supported SBDF type maps to a distinct underlying int.
+    codes = {ValueType.BOOL, ValueType.INT, ValueType.LONG, ValueType.DOUBLE, ValueType.STRING}
+    assert len(codes) == 5
+
+
+def test_infer_types_matches_csv_path() -> None:
+    sample = [["1", "alice", "1.5"], ["2", "bob", "2.5"]]
+    types = infer_types(sample, num_cols=3)
+    assert types == [ValueType.INT, ValueType.STRING, ValueType.DOUBLE]
+
+
+def test_infer_types_pads_short_rows() -> None:
+    sample = [["1"], ["2", "x"]]  # missing column values should be treated as empty
+    types = infer_types(sample, num_cols=3)
+    assert types[0] == ValueType.INT
+    # col 1: one empty + one "x" → string; col 2: all empty → string
+    assert types[1] == ValueType.STRING
+    assert types[2] == ValueType.STRING
+
+
+def test_writer_happy_path_yields_expected_sections() -> None:
+    writer = SbdfStreamingWriter(
+        headers=["id", "name", "value"],
+        column_types=[ValueType.LONG, ValueType.STRING, ValueType.DOUBLE],
+    )
+    batches = [
+        [["1", "Alice", "10.5"], ["2", "Bob", "20.3"]],
+        [["3", "Carol", "30.7"]],
+    ]
+    chunks = list(writer.chunks(iter(batches)))
+
+    # header+metadata, slice #1, slice #2, end marker → 4 chunks.
+    assert len(chunks) == 4
+    combined = b"".join(chunks)
+    assert combined.startswith(_SBDF_MAGIC + bytes([0x01]))  # FileHeader
+    assert combined.endswith(_SBDF_MAGIC + bytes([0x05]))  # TableEnd
+
+
+def test_writer_matches_create_sbdf_byte_for_byte() -> None:
+    # Streaming write with explicit column types should produce the same bytes
+    # as create_sbdf when given the equivalent CSV and chunk boundaries.
+    csv_text = "id,name,value\r\n1,Alice,10.5\r\n2,Bob,20.3\r\n3,Carol,30.7\r\n"
+    buffered = create_sbdf(io.BytesIO(csv_text.encode()), chunk_size=2)
+
+    writer = SbdfStreamingWriter(
+        headers=["id", "name", "value"],
+        column_types=[ValueType.INT, ValueType.STRING, ValueType.DOUBLE],
+    )
+    streamed = b"".join(
+        writer.chunks(
+            iter(
+                [
+                    [["1", "Alice", "10.5"], ["2", "Bob", "20.3"]],
+                    [["3", "Carol", "30.7"]],
+                ]
+            )
+        )
+    )
+
+    assert streamed == buffered
+
+
+def test_writer_low_level_methods() -> None:
+    writer = SbdfStreamingWriter(
+        headers=["n"], column_types=[ValueType.INT]
+    )
+    head = writer.start()
+    slice_bytes = writer.write_slice([["1"], ["2"]])
+    tail = writer.finish()
+
+    assert head.startswith(_SBDF_MAGIC + bytes([0x01]))
+    assert slice_bytes.startswith(_SBDF_MAGIC + bytes([0x03]))  # TableSlice
+    assert tail == _SBDF_MAGIC + bytes([0x05])
+
+
+def test_writer_empty_slice_is_skipped() -> None:
+    writer = SbdfStreamingWriter(
+        headers=["n"], column_types=[ValueType.INT]
+    )
+    writer.start()
+    assert writer.write_slice([]) == b""
+
+
+def test_writer_chunks_skips_empty_batches() -> None:
+    writer = SbdfStreamingWriter(
+        headers=["n"], column_types=[ValueType.INT]
+    )
+    chunks = list(writer.chunks(iter([[["1"]], [], [["2"]]])))
+    # header, slice-1, slice-2, end = 4 chunks (middle empty batch dropped).
+    assert len(chunks) == 4
+
+
+def test_writer_mismatched_header_and_type_count_raises() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        SbdfStreamingWriter(
+            headers=["a", "b"],
+            column_types=[ValueType.INT],
+        )
+
+
+def test_writer_enforces_call_order() -> None:
+    writer = SbdfStreamingWriter(headers=["n"], column_types=[ValueType.INT])
+
+    # write_slice before start
+    with pytest.raises(RuntimeError, match="before start"):
+        writer.write_slice([["1"]])
+
+    # finish before start
+    with pytest.raises(RuntimeError, match="before start"):
+        writer.finish()
+
+    writer.start()
+    with pytest.raises(RuntimeError, match="more than once"):
+        writer.start()
+
+    writer.finish()
+    with pytest.raises(RuntimeError, match="after finish"):
+        writer.write_slice([["1"]])
+    with pytest.raises(RuntimeError, match="more than once"):
+        writer.finish()
+
+
+def test_writer_pads_short_rows_in_slice() -> None:
+    writer = SbdfStreamingWriter(
+        headers=["a", "b", "c"],
+        column_types=[ValueType.STRING, ValueType.STRING, ValueType.STRING],
+    )
+    writer.start()
+    # Short rows should be padded with empty strings — no exception.
+    slice_bytes = writer.write_slice([["x"], ["y", "z"]])
+    assert len(slice_bytes) > 0

--- a/tests/unit/sbdf/test_streaming_writer.py
+++ b/tests/unit/sbdf/test_streaming_writer.py
@@ -23,9 +23,11 @@ def test_value_type_members_distinct() -> None:
         ValueType.INT,
         ValueType.LONG,
         ValueType.DOUBLE,
+        ValueType.DATETIME,
+        ValueType.DATE,
         ValueType.STRING,
     }
-    assert len(codes) == 5
+    assert len(codes) == 7
 
 
 def test_infer_types_matches_csv_path() -> None:
@@ -137,6 +139,61 @@ def test_writer_enforces_call_order() -> None:
         writer.write_slice([["1"]])
     with pytest.raises(RuntimeError, match="more than once"):
         writer.finish()
+
+
+def test_infer_types_detects_date() -> None:
+    sample = [["2025-01-01"], ["2025-06-15"], ["2025-12-31"]]
+    assert infer_types(sample, num_cols=1) == [ValueType.DATE]
+
+
+def test_infer_types_detects_datetime() -> None:
+    sample = [["2025-01-01T12:34:56"], ["2025-06-15 09:00:00"]]
+    assert infer_types(sample, num_cols=1) == [ValueType.DATETIME]
+
+
+def test_infer_types_falls_back_to_string_when_date_parse_fails() -> None:
+    # Some values parse as dates, one does not — whole column becomes string.
+    sample = [["2025-01-01"], ["not-a-date"], ["2025-06-15"]]
+    assert infer_types(sample, num_cols=1) == [ValueType.STRING]
+
+
+def test_writer_date_column_roundtrip_math() -> None:
+    # Sanity-check the Spotfire epoch math: 0001-01-01 UTC → 0 ms.
+    from datetime import datetime, timezone
+
+    from spotfire_community.sbdf._writer import _parse_date_ms
+
+    assert _parse_date_ms("0001-01-01") == 0
+    # 2025-01-01 is a known offset; verify against direct datetime math.
+    expected = int(
+        (
+            datetime(2025, 1, 1, tzinfo=timezone.utc)
+            - datetime(1, 1, 1, tzinfo=timezone.utc)
+        ).total_seconds()
+        * 1000
+    )
+    assert _parse_date_ms("2025-01-01") == expected
+
+
+def test_writer_date_column_emits_int64_per_row() -> None:
+    writer = SbdfStreamingWriter(headers=["d"], column_types=[ValueType.DATE])
+    writer.start()
+    slice_bytes = writer.write_slice([["2025-01-01"], ["2025-06-15"], ["2025-12-31"]])
+    # 3 rows × 8 bytes each for int64 payload.
+    # Inspect the column slice: magic+sid(3) + encoding+vtype(2) + i32 count(4)
+    # + 24 bytes of date values + i32 props(4) minimum.
+    assert len(slice_bytes) >= 3 + 4 + 2 + 4 + 24 + 4
+
+
+def test_writer_invalid_date_marks_row_invalid() -> None:
+    writer = SbdfStreamingWriter(headers=["d"], column_types=[ValueType.DATE])
+    writer.start()
+    slice_bytes = writer.write_slice([["2025-01-01"], ["not-a-date"], [""]])
+    # IsInvalid property must be present — the 2nd and 3rd rows can't parse.
+    # Column props count (int32) is non-zero when any row is invalid.
+    # The int32 right before the end of the slice is the props count;
+    # verify at least one invalid bit is set in the IsInvalid bit array.
+    assert b"IsInvalid" in slice_bytes
 
 
 def test_writer_pads_short_rows_in_slice() -> None:


### PR DESCRIPTION
## Summary
- Adds `SbdfStreamingWriter`, `ValueType`, and `infer_types` to `spotfire_community.sbdf` so callers can produce SBDF bytes incrementally instead of buffering the full file
- Keeps existing `create_sbdf` as a one-shot convenience (unchanged behavior)
- Writer output is byte-identical to `create_sbdf` when given the same batching and column types (covered by test)

## Motivation
Exporting wide Snowflake tables (hundreds of MB to GB of CSV) through `create_sbdf` OOMs in constrained runtimes (e.g. Dagster ECS tasks) because both the CSV input and the SBDF output are held in memory. Giving callers a streaming writer lets them pipe cursor batches straight into a multi-chunk upload without materialising the whole file.

## API
\`\`\`python
from spotfire_community.sbdf import SbdfStreamingWriter, ValueType, infer_types

writer = SbdfStreamingWriter(
    headers=["id", "name", "value"],
    column_types=[ValueType.LONG, ValueType.STRING, ValueType.DOUBLE],
)

def row_batches():
    while True:
        rows = cursor.fetchmany(10_000)
        if not rows:
            break
        yield [[str(v) for v in row] for row in rows]

library_client.upload_file_streaming(
    data_stream=writer.chunks(row_batches()),
    path="/WiseRock/Customer/data.sbdf",
    item_type=ItemType.SBDF,
)
\`\`\`

Low-level methods (`start`, `write_slice`, `finish`) are also exposed for callers who need more control over flow.

Generated with 🤖

Co-Authored-By: Son Of Sergio <sergiojr@wiserocksoftware.com>